### PR TITLE
Kill child processes after rendering

### DIFF
--- a/es5-autogenerated/renderers/browser.js
+++ b/es5-autogenerated/renderers/browser.js
@@ -4,6 +4,8 @@ var _regenerator = require('babel-runtime/regenerator');
 
 var _regenerator2 = _interopRequireDefault(_regenerator);
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -220,11 +222,12 @@ var BrowserRenderer = function () {
                 rootOptions = Prerenderer.getOptions();
                 return _context2.abrupt('return', Promise.all(routes.map(function (route) {
                   return limiter(function () {
-                    opn(`http://localhost:${rootOptions.server.port}${route}`, _this2._rendererOptions.opn);
-
-                    return new Promise(function (resolve, reject) {
-                      _this2._routeEmitter.on(route, function (result) {
-                        resolve(result);
+                    return opn(`http://localhost:${rootOptions.server.port}${route}`, _extends({ wait: false }, _this2._rendererOptions.opn)).then(function (cp) {
+                      return new Promise(function (resolve, reject) {
+                        _this2._routeEmitter.on(route, function (result) {
+                          cp.kill();
+                          resolve(result);
+                        });
                       });
                     });
                   });

--- a/es6/renderers/browser.js
+++ b/es6/renderers/browser.js
@@ -165,13 +165,15 @@ class BrowserRenderer {
     const rootOptions = Prerenderer.getOptions()
 
     return Promise.all(routes.map(route => limiter(() => {
-      opn(`http://localhost:${rootOptions.server.port}${route}`, this._rendererOptions.opn)
-
-      return new Promise((resolve, reject) => {
-        this._routeEmitter.on(route, result => {
-          resolve(result)
-        })
-      })
+      return opn(`http://localhost:${rootOptions.server.port}${route}`, {wait: false, ...this._rendererOptions.opn})
+          .then(cp => {
+              return new Promise((resolve, reject) => {
+                  this._routeEmitter.on(route, result => {
+                      cp.kill()
+                      resolve(result)
+                  })
+              })
+          })
     })))
   }
 


### PR DESCRIPTION
Should fix #2 

Inspired by https://github.com/sindresorhus/opn/issues/43

Tested with prerender-spa-plugin (v3 branch) with following config 
```
renderer: new BrowserRenderer({
  renderAfterTime: 5000,
    opn: {
      app: [
        'google-chrome',
         '--headless',
         '--remote-debugging-port=9222'
      ]
   }
})
```