### PR TITLE
Fix README example bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ prerenderer.initialize()
     try {
       // A smarter implementation would be required, but this does okay for an example.
       // Don't copy this directly!!!
-      const outputDir = path.join(__dirname, 'app', renderedRoute.route
+      const outputDir = path.join(__dirname, 'app', renderedRoute.route)
       const outputFile = `${outputDir}/index.html`
 
       mkdirp.sync(outputDir)


### PR DESCRIPTION
This PR adds a closing paren to a variable declaration in the main example docs provided in README.md.